### PR TITLE
update to Configuration.h

### DIFF
--- a/Marlin/Marlin/Configuration.h
+++ b/Marlin/Marlin/Configuration.h
@@ -29,6 +29,11 @@
 //#define FF_DREAMER_MACHINE
 //#define FF_DREAMER_NX_MACHINE
 //#define FF_DREMEL_3D20_MACHINE
+
+/* Select black or silver pulley */
+//#define FF_BLACK_PULLEY     // steps per unit: X88.9 Y88.9 Z400 E96.3
+#define FF_SILVER_PULLEY     // steps per unit: X94.1 Y94.1 Z400 E96.3
+  
 //#define FF_EXTRUDER_SWAP
 //#define USE_OLD_MARLIN_UI
 //#define USE_MKS_UI
@@ -966,12 +971,17 @@
  * Override with M92
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-/*
-  Black pulley:   X88.90 Y88.90 Z400 E96.56
-  Silver pulley:  X94.14 Y94.14 Z400 E96.56
+/**
+  *Black pulley:   X88.9 Y88.9 Z400 E96.3
+  *Silver pulley:  X94.1 Y94.1 Z400 E96.3
 */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 88.909720, 88.909720, 400.0, 96.275202/*E0*/ }
-
+#if ENABLED(FF_BLACK_PULLEY)
+	#define DEFAULT_AXIS_STEPS_PER_UNIT   { 88.909720, 88.909720, 400.0, 96.275202/*E0*/ }
+#elif ENABLED(FF_SILVER_PULLEY)
+	#define DEFAULT_AXIS_STEPS_PER_UNIT   { 94.139704, 94.139704, 400.0, 96.275202/*E0*/ }
+#else
+	#error Invalid pulley selection
+#endif
 /**
  * Default Max Feed Rate (mm/s)
  * Override with M203

--- a/Marlin/Marlin/Configuration.h
+++ b/Marlin/Marlin/Configuration.h
@@ -21,6 +21,10 @@
  */
 #pragma once
 
+//===========================================================================
+//========================== Setup Printer Here =============================
+//===========================================================================
+
 /* you must be sure what you know what you do :) */
 #define FF_FLASHAIR_FIX   //...
 #define FF_RUSSIAN_FIX   //...
@@ -38,7 +42,6 @@
 
 /* Switch left and right extruder */ 
 //#define FF_EXTRUDER_SWAP
-
 #if NONE(FF_DREAMER_MACHINE, FF_INVENTOR_MACHINE) && ENABLED( FF_EXTRUDER_SWAP )
 #error FF_EXTRUDER_SWAP works only with dreamer and inventor
 #endif
@@ -51,6 +54,8 @@
 #if ENABLED( FF_DREMEL_3D20_MACHINE )
 #define FF_DREAMER_NX_MACHINE
 #endif
+
+//===========================================================================
 
 /**
  * Configuration.h

--- a/Marlin/Marlin/Configuration.h
+++ b/Marlin/Marlin/Configuration.h
@@ -55,7 +55,6 @@
 #define FF_DREAMER_NX_MACHINE
 #endif
 
-//===========================================================================
 
 /**
  * Configuration.h
@@ -1426,7 +1425,7 @@
  */
 #define Z_IDLE_HEIGHT Z_HOME_POS
 
-//#define Z_HOMING_HEIGHT  0      // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
+//#define Z_HOMING_HEIGHT  4      // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
                                   // Be sure to have this much clearance over your Z_MAX_POS to prevent grinding.
 
 //#define Z_AFTER_HOMING  10      // (mm) Height to move to after homing Z

--- a/Marlin/Marlin/Configuration.h
+++ b/Marlin/Marlin/Configuration.h
@@ -21,14 +21,10 @@
  */
 #pragma once
 
-//===========================================================================
-//========================== Setup Printer Here =============================
-//===========================================================================
-
 /* you must be sure what you know what you do :) */
-#define FF_FLASHAIR_FIX   //...
-#define FF_RUSSIAN_FIX   //...
-#define FF_M907_PROTECTION   //...
+#define FF_FLASHAIR_FIX
+#define FF_RUSSIAN_FIX
+#define FF_M907_PROTECTION
 
 /* Select one of the printers below */
 //#define FF_INVENTOR_MACHINE
@@ -37,8 +33,12 @@
 //#define FF_DREMEL_3D20_MACHINE
 
 /* Select black or silver pulley */
-//#define FF_BLACK_PULLEY     // steps per unit: X88.9 Y88.9 Z400 E96.3
-//#define FF_SILVER_PULLEY     // steps per unit: X94.1 Y94.1 Z400 E96.3
+//#define FF_BLACK_PULLEY
+//#define FF_SILVER_PULLEY
+
+#if NONE(FF_BLACK_PULLEY, FF_SILVER_PULLEY)
+#define FF_BLACK_PULLEY
+#endif
 
 /* Switch left and right extruder */ 
 //#define FF_EXTRUDER_SWAP

--- a/Marlin/Marlin/Configuration.h
+++ b/Marlin/Marlin/Configuration.h
@@ -32,7 +32,7 @@
 
 /* Select black or silver pulley */
 //#define FF_BLACK_PULLEY     // steps per unit: X88.9 Y88.9 Z400 E96.3
-#define FF_SILVER_PULLEY     // steps per unit: X94.1 Y94.1 Z400 E96.3
+//#define FF_SILVER_PULLEY     // steps per unit: X94.1 Y94.1 Z400 E96.3
   
 //#define FF_EXTRUDER_SWAP
 //#define USE_OLD_MARLIN_UI

--- a/Marlin/Marlin/Configuration.h
+++ b/Marlin/Marlin/Configuration.h
@@ -1406,7 +1406,7 @@
  */
 #define Z_IDLE_HEIGHT Z_HOME_POS
 
-//#define Z_HOMING_HEIGHT  4      // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
+//#define Z_HOMING_HEIGHT  0      // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
                                   // Be sure to have this much clearance over your Z_MAX_POS to prevent grinding.
 
 //#define Z_AFTER_HOMING  10      // (mm) Height to move to after homing Z
@@ -1460,7 +1460,7 @@
 #if ENABLED(FF_INVENTOR_MACHINE)
 #define Z_MAX_POS 155
 #else
-#define Z_MAX_POS 150 /* original 140 */
+#define Z_MAX_POS 140
 #endif
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50

--- a/Marlin/Marlin/Configuration.h
+++ b/Marlin/Marlin/Configuration.h
@@ -22,9 +22,11 @@
 #pragma once
 
 /* you must be sure what you know what you do :) */
-#define FF_FLASHAIR_FIX
-#define FF_RUSSIAN_FIX
-#define FF_M907_PROTECTION
+#define FF_FLASHAIR_FIX   //...
+#define FF_RUSSIAN_FIX   //...
+#define FF_M907_PROTECTION   //...
+
+/* Select one of the printers below */
 //#define FF_INVENTOR_MACHINE
 //#define FF_DREAMER_MACHINE
 //#define FF_DREAMER_NX_MACHINE
@@ -33,18 +35,21 @@
 /* Select black or silver pulley */
 //#define FF_BLACK_PULLEY     // steps per unit: X88.9 Y88.9 Z400 E96.3
 //#define FF_SILVER_PULLEY     // steps per unit: X94.1 Y94.1 Z400 E96.3
-  
+
+/* Switch left and right extruder */ 
 //#define FF_EXTRUDER_SWAP
+
+#if NONE(FF_DREAMER_MACHINE, FF_INVENTOR_MACHINE) && ENABLED( FF_EXTRUDER_SWAP )
+#error FF_EXTRUDER_SWAP works only with dreamer and inventor
+#endif
+
+/* Select UI type */ 
 //#define USE_OLD_MARLIN_UI
 //#define USE_MKS_UI
 
 /* NX and 3D20 mostly same, but 3D20 does not have heated bed and chamber */
 #if ENABLED( FF_DREMEL_3D20_MACHINE )
 #define FF_DREAMER_NX_MACHINE
-#endif
-
-#if NONE(FF_DREAMER_MACHINE, FF_INVENTOR_MACHINE) && ENABLED( FF_EXTRUDER_SWAP )
-#error FF_EXTRUDER_SWAP works only with dreamer and inventor
 #endif
 
 /**


### PR DESCRIPTION
Changed Z_HOMING_HEIGHT back to original 140mm >> so that the print bed cannot touch the bottom. when G28 is performed with bed in lowest position 

 Z_MAX_POS set to 0 >> bed does not go down first when G28 is performed, and so the bed cannot touch the bottom when bed is in lowest position (like original in FlashForge firmware)

added silver and black pulley selection, correct selection in very important to avoid collision
