### PR TITLE
add powerspec machine type support

### DIFF
--- a/marlin_builder.sh
+++ b/marlin_builder.sh
@@ -19,7 +19,7 @@ function usage()
 
    arguments:
      -h           show this help message and exit
-     -m           machine name ( nx/dreamer/inventor )
+     -m           machine name ( nx/dreamer/inventor/powerspec )
      -s           swap extruders ( for dreamer and inventor machines )
      -o           use Dreamer old motherboard ( swap extruder DIR )
      -l           enable linear advance ( pressure control algo )
@@ -92,6 +92,9 @@ elif [[ "$machine" == "dremel" ]]
 then
    flags+="-DFF_DREMEL_3D20_MACHINE"
    encryption_key="flashforge123456"
+elif [[ "$machine" == "powerspec" ]]
+then
+   flags+="-DFF_DREAMER_MACHINE -DFF_SILVER_PULLEY -DFF_EXTRUDER_SWAP"
 else
    usage
    exit

--- a/marlin_builder.sh
+++ b/marlin_builder.sh
@@ -94,7 +94,7 @@ then
    encryption_key="flashforge123456"
 elif [[ "$machine" == "powerspec" ]]
 then
-   flags+="-DFF_DREAMER_MACHINE -DFF_SILVER_PULLEY -DFF_EXTRUDER_SWAP"
+   flags+="-DFF_DREAMER_MACHINE -DFF_SILVER_PULLEY -DFF_EXTRUDER_SWAP -DFF_DREAMER_OLD_MB"
 else
    usage
    exit


### PR DESCRIPTION
support for PowerSpec Ultra3D printer, which is dreamer re-brand, but has "silver" pulley which has different pitch requiring x/y steps also, makes sense to have left extruder first, as this makes the display orientation of the extruders match the physical layout of extruders in the build chamber